### PR TITLE
chore: gas savings audit changes

### DIFF
--- a/contracts/Automate.sol
+++ b/contracts/Automate.sol
@@ -184,9 +184,11 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
             _createdTasks
         );
 
-        emit LibEvents.ExecBypassModuleSuccess(_taskId, success);
-
-        emit LogUseGelato1Balance(_correlationId);
+        emit LibEvents.ExecBypassModuleSuccess(
+            _taskId,
+            _correlationId,
+            success
+        );
     }
 
     ///@inheritdoc IAutomate

--- a/contracts/Automate.sol
+++ b/contracts/Automate.sol
@@ -181,7 +181,7 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
             _execData,
             _revertOnFailure,
             _singleExec,
-            taskModuleAddresses
+            _createdTasks
         );
 
         emit LibEvents.ExecSuccess1BalanceSimple(_taskId, success);

--- a/contracts/Automate.sol
+++ b/contracts/Automate.sol
@@ -12,7 +12,7 @@ import {LibDataTypes} from "./libraries/LibDataTypes.sol";
 import {LibEvents} from "./libraries/LibEvents.sol";
 import {LibTaskId} from "./libraries/LibTaskId.sol";
 import {LibTaskModule} from "./libraries/LibTaskModule.sol";
-import {LibSimpleTaskModule} from "./libraries/LibSimpleTaskModule.sol";
+import {LibBypassModule} from "./libraries/LibBypassModule.sol";
 import {IAutomate} from "./interfaces/IAutomate.sol";
 
 /**
@@ -160,7 +160,7 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
     }
 
     ///@inheritdoc IAutomate
-    function exec1BalanceSimple(
+    function execBypassModule(
         address _taskCreator,
         address _execAddress,
         bytes32 _taskId,
@@ -174,7 +174,7 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
             "Automate.exec: Task not found"
         );
 
-        bool success = LibSimpleTaskModule.onExecTask(
+        bool success = LibBypassModule.onExecTask(
             _taskId,
             _taskCreator,
             _execAddress,
@@ -184,7 +184,7 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
             _createdTasks
         );
 
-        emit LibEvents.ExecSuccess1BalanceSimple(_taskId, success);
+        emit LibEvents.ExecBypassModuleSuccess(_taskId, success);
 
         emit LogUseGelato1Balance(_correlationId);
     }

--- a/contracts/Automate.sol
+++ b/contracts/Automate.sol
@@ -159,6 +159,40 @@ contract Automate is Gelatofied, Proxied, AutomateStorage, IAutomate {
         emit LogUseGelato1Balance(_oneBalanceParam.correlationId);
     }
 
+    function execBypassModuleSyncFee(
+        address _taskCreator,
+        address _execAddress,
+        bytes32 _taskId,
+        uint256 _txFee,
+        address _feeToken,
+        bytes memory _execData,
+        bool _revertOnFailure,
+        bool _singleExec
+    ) external onlyGelato {
+        require(
+            _createdTasks[_taskCreator].contains(_taskId),
+            "Automate.exec: Task not found"
+        );
+
+        fee = _txFee;
+        feeToken = _feeToken;
+
+        bool success = LibBypassModule.onExecTask(
+            _taskId,
+            _taskCreator,
+            _execAddress,
+            _execData,
+            _revertOnFailure,
+            _singleExec,
+            _createdTasks
+        );
+
+        delete fee;
+        delete feeToken;
+
+        emit LibEvents.ExecBypassModuleSuccess(_taskId, bytes32(""), success);
+    }
+
     ///@inheritdoc IAutomate
     function execBypassModule(
         address _taskCreator,

--- a/contracts/interfaces/IAutomate.sol
+++ b/contracts/interfaces/IAutomate.sol
@@ -91,6 +91,29 @@ interface IAutomate is IGelato1Balance {
     ) external;
 
     /**
+     * @notice Execution API called by Gelato, using Gelato Sync fee as fee payment method.
+     *
+     * @param taskCreator The address which created the task.
+     * @param execAddress Address of contract that should be called by Gelato.
+     * @param taskId Unique hash of the task.
+     * @param txFee Fee paid to Gelato for execution, transfered to Gelato.feeCollector().
+     * @param feeToken Token used to pay for the execution. ETH = 0xeeeeee...
+     * @param execData Execution data to be called with / function selector if execution data is yet to be determined.
+     * @param revertOnFailure To revert or not if call to execAddress fails. (Used for off-chain simulations)
+     * @param singleExec If the task is a SingleExec task. If true, task will be cancelled after execution.
+     */
+    function execBypassModuleSyncFee(
+        address taskCreator,
+        address execAddress,
+        bytes32 taskId,
+        uint256 txFee,
+        address feeToken,
+        bytes memory execData,
+        bool revertOnFailure,
+        bool singleExec
+    ) external;
+
+    /**
      * @notice Sets the address of task modules. Only callable by proxy admin.
      *
      * @param modules List of modules to be set

--- a/contracts/interfaces/IAutomate.sol
+++ b/contracts/interfaces/IAutomate.sol
@@ -80,7 +80,7 @@ interface IAutomate is IGelato1Balance {
      * @param revertOnFailure To revert or not if call to execAddress fails. (Used for off-chain simulations)
      * @param singleExec If the task is a SingleExec task. If true, task will be cancelled after execution.
      */
-    function exec1BalanceSimple(
+    function execBypassModule(
         address taskCreator,
         address execAddress,
         bytes32 taskId,

--- a/contracts/libraries/LibBypassModule.sol
+++ b/contracts/libraries/LibBypassModule.sol
@@ -14,7 +14,7 @@ import {ITaskModule} from "../interfaces/ITaskModule.sol";
 
 // solhint-disable function-max-lines
 /// @notice Simplified library for task executions
-library LibSimpleTaskModule {
+library LibBypassModule {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using LibTaskModuleConfig for LibDataTypes.Module;
 

--- a/contracts/libraries/LibEvents.sol
+++ b/contracts/libraries/LibEvents.sol
@@ -55,7 +55,12 @@ library LibEvents {
      * @notice Emitted when `execBypassModule` is called.
      *
      * @param taskId Unique hash of the task. {See LibTaskId-getTaskId}
+     * @param correlationId Id of the execution to be used for 1Balance settlement.
      * @param callSuccess Status of the call to execAddress.
      */
-    event ExecBypassModuleSuccess(bytes32 taskId, bool callSuccess);
+    event ExecBypassModuleSuccess(
+        bytes32 taskId,
+        bytes32 correlationId,
+        bool callSuccess
+    );
 }

--- a/contracts/libraries/LibEvents.sol
+++ b/contracts/libraries/LibEvents.sol
@@ -52,10 +52,10 @@ library LibEvents {
     );
 
     /**
-     * @notice Emitted when `exec1BalanceSimple` is called.
+     * @notice Emitted when `execBypassModule` is called.
      *
      * @param taskId Unique hash of the task. {See LibTaskId-getTaskId}
      * @param callSuccess Status of the call to execAddress.
      */
-    event ExecSuccess1BalanceSimple(bytes32 taskId, bool callSuccess);
+    event ExecBypassModuleSuccess(bytes32 taskId, bool callSuccess);
 }

--- a/contracts/opsProxy/OpsProxy.sol
+++ b/contracts/opsProxy/OpsProxy.sol
@@ -63,7 +63,15 @@ contract OpsProxy is Proxied, IOpsProxy {
         bytes calldata _data,
         uint256 _value
     ) private {
-        _call(_target, _data, _value, true, "OpsProxy.executeCall: ");
+        (, bytes memory returnData) = _call(
+            _target,
+            _data,
+            _value,
+            true,
+            "OpsProxy.executeCall: "
+        );
+
+        emit ExecuteCall(_target, _data, _value, returnData);
     }
 
     function _getTaskCreator() private pure returns (address taskCreator) {

--- a/test/Automate-multiModule.test.ts
+++ b/test/Automate-multiModule.test.ts
@@ -233,7 +233,7 @@ describe("Automate multi module test", function () {
     expect(countAfter).to.be.gt(countBefore);
   });
 
-  it("exec1BalanceSimple", async () => {
+  it("execBypassModule", async () => {
     const countBefore = await counter.count();
     const [, execData] = await counterResolver.checker();
 
@@ -245,7 +245,7 @@ describe("Automate multi module test", function () {
 
     await automate
       .connect(executor)
-      .exec1BalanceSimple(
+      .execBypassModule(
         userAddress,
         opsProxy.address,
         taskId,

--- a/test/Automate-singleExec.test.ts
+++ b/test/Automate-singleExec.test.ts
@@ -116,12 +116,12 @@ describe("Automate SingleExec module test", function () {
     expect(taskIds).not.include(taskId);
   });
 
-  it("exec1BalanceSimple", async () => {
+  it("execBypassModule", async () => {
     const countBefore = await counter.count();
 
     await automate
       .connect(executor)
-      .exec1BalanceSimple(
+      .execBypassModule(
         userAddress,
         counter.address,
         taskId,

--- a/test/Automate-withoutTreasury.test.ts
+++ b/test/Automate-withoutTreasury.test.ts
@@ -111,7 +111,53 @@ describe("Automate Without 1Balance test", function () {
     expect(countAfter).to.be.gt(countBefore);
 
     const taskIds = await automate.getTaskIdsByUser(userAddress);
-    expect(taskIds).not.include(taskId);
+    expect(taskIds).to.not.include(taskId);
+  });
+
+  it("execBypassModuleSyncFee", async () => {
+    const countBefore = await counterWT.count();
+
+    await automate
+      .connect(executor)
+      .execBypassModuleSyncFee(
+        userAddress,
+        counterWT.address,
+        taskId,
+        FEE,
+        ETH,
+        execData,
+        false,
+        false
+      );
+
+    const countAfter = await counterWT.count();
+    expect(countAfter).to.be.gt(countBefore);
+
+    const taskIds = await automate.getTaskIdsByUser(userAddress);
+    expect(taskIds).to.include(taskId);
+  });
+
+  it("execBypassModuleSyncFee - singleExec", async () => {
+    const countBefore = await counterWT.count();
+
+    await automate
+      .connect(executor)
+      .execBypassModuleSyncFee(
+        userAddress,
+        counterWT.address,
+        taskId,
+        FEE,
+        ETH,
+        execData,
+        false,
+        true
+      );
+
+    const countAfter = await counterWT.count();
+    expect(countAfter).to.be.gt(countBefore);
+
+    const taskIds = await automate.getTaskIdsByUser(userAddress);
+    expect(taskIds).to.not.include(taskId);
   });
 
   it("send funds to feeCollector", async () => {


### PR DESCRIPTION
Audit report: https://notes.watchpug.com/p/18cb3b30088GDV1y#n_3

[[WP-G2] Merging the events LogUseGelato1Balance and ExecSuccess1Balance can save gas.
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_4)

Not implemented as we have to follow 1Balance standard (check if 1Balance team)

[[WP-G3] The taskModules design may be over-engineering (for the current application).
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_9)[[WP-G5] Redundant SLOAD taskModuleAddresses.
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_11)

My view is that we will keep the modules and `exec1Balance` as it is to avoid a huge refactor. However, `execBypassModule` will be the preferred execution method and we will transition into using this.

[[WP-I6] Idea: If we remove _execAddress from calldata and instead calculate it based on _taskCreator or read it from storage, it might be cheaper on L2.](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_5)

To achieve this, we have to determine the dedicated msg sender via a call to `OpsProxyFactory`. `OpsProxyFactory` has to be stored as storage (1 read) / queried dynamically from the OpsProxy Module contract (which will require 1 state read & 1 call). 

I prefer to keep `_execAddress` so that `execBypassModule` can be used to execute tasks that do not enable `PROXY` module.

[[WP-O7] _call() and _delegateCall() will discard custom error information and instead revert with "NoErrorSelector".
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_14)[[WP-G8] Unnecessary internal function calls
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_15)[[WP-G9] Add OpsProxyFactory.proxyOf(address _account) storage getter to save unnecessary computation and gas waste from SLOAD.
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_18)[[WP-I10] Idea: Make the Automate contract inherit OpsProxyFactory (Automate is OpsProxyFactory) can reducing external calls.
](https://notes.watchpug.com/p/18cb3b30088GDV1y#n_18)

I see these as major changes and will also alter the addresses of user's dedicated msg sender which we want to avoid as of now. 


